### PR TITLE
fix: hash onion auth

### DIFF
--- a/specs/interop/storage-upgrade.md
+++ b/specs/interop/storage-upgrade.md
@@ -38,7 +38,8 @@ and add the following functionality:
 bytes32 public hashOnion;
 
 function setHashOnion(bytes32 _hashOnion) external {
-    require(msg.sender == Predeploys.PROXY_ADMIN, "Unauthorized");
+    require(msg.sender == Predeploys.L2_CROSS_DOMAIN_MESSENGER, "Unauthorized");
+    require((Predeploys.L2_CROSS_DOMAIN_MESSENGER).xDomainMessageSender() == (Predeploys.PROXY_ADMIN).owner(), "Unauthorized");
     require(hashOnion == 0, "Already initialized");
 
     hashOnion = _hashOnion;

--- a/specs/interop/storage-upgrade.md
+++ b/specs/interop/storage-upgrade.md
@@ -39,7 +39,10 @@ bytes32 public hashOnion;
 
 function setHashOnion(bytes32 _hashOnion) external {
     require(msg.sender == Predeploys.L2_CROSS_DOMAIN_MESSENGER, "Unauthorized");
-    require((Predeploys.L2_CROSS_DOMAIN_MESSENGER).xDomainMessageSender() == (Predeploys.PROXY_ADMIN).owner(), "Unauthorized");
+
+    require((Predeploys.L2_CROSS_DOMAIN_MESSENGER).xDomainMessageSender() ==
+        AddressAliasHelper.undoL1ToL2Alias((Predeploys.PROXY_ADMIN).owner()), "Unauthorized");
+
     require(hashOnion == 0, "Already initialized");
 
     hashOnion = _hashOnion;


### PR DESCRIPTION
We have been researching with gotzen and to have the correct sender from L1 we found two importante things:

1. The `msg.sender` at this point will be the `L2CrossDomainMessenger`. We should have a check for this.
2. The `msg.sender` from L1 will be on `xDomainMessageSender`. This has to be the un-aliased L2 ProxyAdmin owner.
